### PR TITLE
Bump version to 1.2.2 and refactor type handling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 	<Product>Choice generator</Product>
 	<Company>ALTA Software llc.</Company>
 	<Copyright>Copyright © 2024 ALTA Software llc.</Copyright>
-	<Version>1.2.1</Version>
+	<Version>1.2.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AltaSoft.Choice.Generator/Executor.cs
+++ b/src/AltaSoft.Choice.Generator/Executor.cs
@@ -206,7 +206,7 @@ internal static class Executor
         var xmlTagAttribute = propertySymbol.GetAttributes().FirstOrDefault(x => x.AttributeClass?.ToDisplayString() == Constants.XmlTagAttributeFullName);
         var xmlElementName = (string?)xmlTagAttribute?.ConstructorArguments[0].Value ?? propertySymbol.Name;
 
-        var typeFullName = propertySymbol.Type.GetFriendlyName();
+        var typeFullName = propertySymbol.Type.GetFullName();
         var propertyName = propertySymbol.Name;
 
         return new PropertyDetails(

--- a/src/AltaSoft.Choice.Generator/Extensions/CompilationExt.cs
+++ b/src/AltaSoft.Choice.Generator/Extensions/CompilationExt.cs
@@ -180,42 +180,6 @@ internal static class CompilationExt
         friendlyName += ">";
         return ns + '.' + friendlyName;
     }
-    public static string GetFriendlyName(this ITypeSymbol type)
-    {
-        var ns = type.ContainingNamespace?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining))!;
-
-        if (s_typeAliases.TryGetValue(ns + "." + type.MetadataName, out var result))
-        {
-            return result;
-        }
-
-        var friendlyName = type.MetadataName;
-        if (friendlyName.Length == 0)
-            friendlyName = type.OriginalDefinition.ToDisplayString();
-
-        if (type is not INamedTypeSymbol namedType)
-            return friendlyName;
-
-        if (!namedType.IsGenericType)
-            return friendlyName;
-
-        if (namedType.IsNullableValueType(out var underlyingType))
-            return underlyingType!.GetFullName();
-
-        var iBacktick = friendlyName.IndexOf('`');
-        if (iBacktick > 0)
-            friendlyName = friendlyName.Remove(iBacktick);
-        friendlyName += "<";
-
-        var typeParameters = namedType.TypeArguments;
-        for (var i = 0; i < typeParameters.Length; ++i)
-        {
-            var typeParamName = typeParameters[i].ToString();
-            friendlyName += i == 0 ? typeParamName : "," + typeParamName;
-        }
-        friendlyName += ">";
-        return friendlyName;
-    }
 
     /// <summary>
     /// Determines whether the specified type symbol is a Nullable&lt;T&gt; value type and, if so, provides the underlying value type symbol.

--- a/src/AltaSoft.Choice.Generator/Extensions/RoslynExt.cs
+++ b/src/AltaSoft.Choice.Generator/Extensions/RoslynExt.cs
@@ -82,15 +82,15 @@ internal static class RoslynExt
     /// <returns>The namespace from the base namespace declaration.</returns>
     public static string GetNamespace(this BaseNamespaceDeclarationSyntax self) => self.Name.ToString();
 
-    ///// <summary>
-    ///// Gets the fully qualified name of the specified type declaration syntax, including its namespace.
-    ///// </summary>
-    ///// <param name="self">The type declaration syntax to retrieve the fully qualified name from.</param>
-    ///// <returns>The fully qualified name of the type declaration.</returns>
-    //public static string GetClassFullName(this TypeDeclarationSyntax self)
-    //{
-    //    return self.GetNamespace() + "." + self.GetClassName();
-    //}
+    /// <summary>
+    /// Gets the fully qualified name of the specified type declaration syntax, including its namespace.
+    /// </summary>
+    /// <param name="self">The type declaration syntax to retrieve the fully qualified name from.</param>
+    /// <returns>The fully qualified name of the type declaration.</returns>
+    public static string GetClassFullName(this TypeDeclarationSyntax self)
+    {
+        return self.GetNamespace() + "." + self.GetClassName();
+    }
 
     /// <summary>
     /// Gets the name of the class specified in the type declaration syntax.

--- a/tests/AltaSoft.Choice.Generator.SnapshotTests/ChoiceGeneratorTest.cs
+++ b/tests/AltaSoft.Choice.Generator.SnapshotTests/ChoiceGeneratorTest.cs
@@ -25,33 +25,37 @@ public class ChoiceGeneratorTest
             using System.Xml.Schema;
             using System.Xml.Serialization;
             using AltaSoft.Choice;
+            using TestNamespace.OtherNamespace;
                               
-            namespace TestNamespace;
-                              
-            [Choice]
-            public sealed partial class Authorisation1Choice
+            namespace TestNamespace
             {
-                              
-                /// <summary>
-                /// <para>Specifies the authorisation, in a coded form.</para>
-                /// </summary>
-                [XmlElement("Cd")]
-                                 
-                public partial Authorisation1Code? Code { get; set; }
-                                   
-                /// <summary>
-                /// <para>Specifies the authorisation, in a free text form.</para>
-                /// </summary>
-                [XmlElement("Prtry")]
-                                 
-                public partial string? Proprietary { get; set; }
-                              
+                [Choice]
+                public sealed partial class Authorisation1Choice
+                {
+                    /// <summary>
+                    /// <para>Specifies the authorisation, in a coded form.</para>
+                    /// </summary>
+                    [XmlElement("Cd")]
+                                     
+                    public partial Authorisation1Code? Code { get; set; }
+                                       
+                    /// <summary>
+                    /// <para>Specifies the authorisation, in a free text form.</para>
+                    /// </summary>
+                    [XmlElement("Prtry")]
+                                     
+                    public partial string? Proprietary { get; set; }
+                                  
+                }
             }
-                              
-            public enum Authorisation1Code
+                           
+            namespace TestNamespace.OtherNamespace
             {
-                One,
-                Two
+                public enum Authorisation1Code
+                {
+                    One,
+                    Two
+                }
             }
             """;
 
@@ -71,27 +75,37 @@ public class ChoiceGeneratorTest
             using System.Xml.Schema;
             using System.Xml.Serialization;
             using AltaSoft.Choice;
+            using TestNamespace.OtherNamespace;
                               
-            namespace TestNamespace;
-                              
-            [Choice]
-            public sealed partial class Authorisation1Choice
+            namespace TestNamespace
             {
-                              
-                /// <summary>
-                /// <para>Specifies the authorisation, in a coded form.</para>
-                /// </summary>
-                [XmlElement("Cd")]
-                                 
-                public partial string? Code { get; set; }
-                                   
-                /// <summary>
-                /// <para>Specifies the authorisation, in a free text form.</para>
-                /// </summary>
-                [XmlElement("Prtry")]
-                                 
-                public partial string? Proprietary { get; set; }
-                              
+                [Choice]
+                public sealed partial class Authorisation1Choice
+                {
+                                  
+                    /// <summary>
+                    /// <para>Specifies the authorisation, in a coded form.</para>
+                    /// </summary>
+                    [XmlElement("Cd")]
+                                     
+                    public partial string? Code { get; set; }
+                                       
+                    /// <summary>
+                    /// <para>Specifies the authorisation, in a free text form.</para>
+                    /// </summary>
+                    [XmlElement("Prtry")]
+                                     
+                    public partial Authorisation1Code? Proprietary { get; set; }
+                }
+            }
+            
+            namespace TestNamespace.OtherNamespace
+            {
+                public enum Authorisation1Code
+                {
+                    One,
+                    Two
+                }
             }
             """;
 

--- a/tests/AltaSoft.Choice.Generator.SnapshotTests/Snapshots/ChoiceGeneratorTest.ChoiceTypeShouldGenerateAllMethodsAndCompileCorrectly#Authorisation1Choice.g.verified.cs
+++ b/tests/AltaSoft.Choice.Generator.SnapshotTests/Snapshots/ChoiceGeneratorTest.ChoiceTypeShouldGenerateAllMethodsAndCompileCorrectly#Authorisation1Choice.g.verified.cs
@@ -39,14 +39,14 @@ public sealed partial class Authorisation1Choice
     [XmlIgnore]
     public ChoiceOf ChoiceType { get; private set; }
 
-    private TestNamespace.Authorisation1Code? _code;
+    private TestNamespace.OtherNamespace.Authorisation1Code? _code;
 
     /// <summary>
     /// Specifies the authorisation, in a coded form.
     /// </summary>
     [DisallowNull]
     [XmlElement("Code")]
-    public partial TestNamespace.Authorisation1Code? Code
+    public partial TestNamespace.OtherNamespace.Authorisation1Code? Code
     {
         get => _code;
         set
@@ -77,10 +77,10 @@ public sealed partial class Authorisation1Choice
 
 
     /// <summary>
-    /// Creates a new <see cref="TestNamespace.Authorisation1Choice"/> instance and sets its value using the specified <see cref="TestNamespace.Authorisation1Code"/>.
+    /// Creates a new <see cref="TestNamespace.Authorisation1Choice"/> instance and sets its value using the specified <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/>.
     /// </summary>
     /// <param name="value">The value to assign to the created choice instance.</param>
-    public static TestNamespace.Authorisation1Choice CreateAsCode(TestNamespace.Authorisation1Code value) => new () { Code = value };
+    public static TestNamespace.Authorisation1Choice CreateAsCode(TestNamespace.OtherNamespace.Authorisation1Code value) => new () { Code = value };
 
     /// <summary>
     /// Creates a new <see cref="TestNamespace.Authorisation1Choice"/> instance and sets its value using the specified <see cref="string"/>.
@@ -95,7 +95,7 @@ public sealed partial class Authorisation1Choice
     /// <param name="matchCode">Function to invoke if the choice is a <see cref="ChoiceOf.Code"/> value</param>
     /// <param name="matchProprietary">Function to invoke if the choice is a <see cref="ChoiceOf.Proprietary"/> value</param>
     public TResult Match<TResult>(
-    	Func<TestNamespace.Authorisation1Code, TResult> matchCode, 
+    	Func<TestNamespace.OtherNamespace.Authorisation1Code, TResult> matchCode, 
     	Func<string, TResult> matchProprietary)
     {
         return ChoiceType switch
@@ -112,7 +112,7 @@ public sealed partial class Authorisation1Choice
     /// <param name="matchCode">Action to invoke if the choice is a <see cref="ChoiceOf.Code"/> value</param>
     /// <param name="matchProprietary">Action to invoke if the choice is a <see cref="ChoiceOf.Proprietary"/> value</param>
     public void Switch(
-    	Action<TestNamespace.Authorisation1Code> matchCode, 
+    	Action<TestNamespace.OtherNamespace.Authorisation1Code> matchCode, 
     	Action<string> matchProprietary)
     {
         switch (ChoiceType)
@@ -131,13 +131,13 @@ public sealed partial class Authorisation1Choice
     }
 
     /// <summary>
-    /// Implicitly converts an <see cref="TestNamespace.Authorisation1Code"/> to an <see cref="Authorisation1Choice"/>.
+    /// Implicitly converts an <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/> to an <see cref="Authorisation1Choice"/>.
     /// </summary>
-    /// <param name="value">The <see cref="TestNamespace.Authorisation1Code"/> to convert.</param>
+    /// <param name="value">The <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/> to convert.</param>
     /// <returns>
     /// <see cref="Authorisation1Choice"/> instance representing the code.
     /// </returns>
-    public static implicit operator Authorisation1Choice(TestNamespace.Authorisation1Code value) => CreateAsCode(value);
+    public static implicit operator Authorisation1Choice(TestNamespace.OtherNamespace.Authorisation1Code value) => CreateAsCode(value);
 
     /// <summary>
     /// Implicitly converts an <see cref="string"/> to an <see cref="Authorisation1Choice"/>.

--- a/tests/AltaSoft.Choice.Generator.SnapshotTests/Snapshots/ChoiceGeneratorTest.ChoiceTypeShouldNotGenerateImplicitMethodsAndCompileCorrectly#Authorisation1Choice.g.verified.cs
+++ b/tests/AltaSoft.Choice.Generator.SnapshotTests/Snapshots/ChoiceGeneratorTest.ChoiceTypeShouldNotGenerateImplicitMethodsAndCompileCorrectly#Authorisation1Choice.g.verified.cs
@@ -57,14 +57,14 @@ public sealed partial class Authorisation1Choice
         }
     }
 
-    private string? _proprietary;
+    private TestNamespace.OtherNamespace.Authorisation1Code? _proprietary;
 
     /// <summary>
     /// Specifies the authorisation, in a free text form.
     /// </summary>
     [DisallowNull]
     [XmlElement("Proprietary")]
-    public partial string? Proprietary
+    public partial TestNamespace.OtherNamespace.Authorisation1Code? Proprietary
     {
         get => _proprietary;
         set
@@ -83,10 +83,10 @@ public sealed partial class Authorisation1Choice
     public static TestNamespace.Authorisation1Choice CreateAsCode(string value) => new () { Code = value };
 
     /// <summary>
-    /// Creates a new <see cref="TestNamespace.Authorisation1Choice"/> instance and sets its value using the specified <see cref="string"/>.
+    /// Creates a new <see cref="TestNamespace.Authorisation1Choice"/> instance and sets its value using the specified <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/>.
     /// </summary>
     /// <param name="value">The value to assign to the created choice instance.</param>
-    public static TestNamespace.Authorisation1Choice CreateAsProprietary(string value) => new () { Proprietary = value };
+    public static TestNamespace.Authorisation1Choice CreateAsProprietary(TestNamespace.OtherNamespace.Authorisation1Code value) => new () { Proprietary = value };
 
     /// <summary>
     /// <para>Applies the appropriate function based on the current choice type</para>
@@ -96,12 +96,12 @@ public sealed partial class Authorisation1Choice
     /// <param name="matchProprietary">Function to invoke if the choice is a <see cref="ChoiceOf.Proprietary"/> value</param>
     public TResult Match<TResult>(
     	Func<string, TResult> matchCode, 
-    	Func<string, TResult> matchProprietary)
+    	Func<TestNamespace.OtherNamespace.Authorisation1Code, TResult> matchProprietary)
     {
         return ChoiceType switch
         {
             ChoiceOf.Code => matchCode(Code!),
-            ChoiceOf.Proprietary => matchProprietary(Proprietary!),
+            ChoiceOf.Proprietary => matchProprietary(Proprietary!.Value),
             _ => throw new InvalidOperationException($"Invalid ChoiceType. '{ChoiceType}'")
         };
     }
@@ -113,7 +113,7 @@ public sealed partial class Authorisation1Choice
     /// <param name="matchProprietary">Action to invoke if the choice is a <see cref="ChoiceOf.Proprietary"/> value</param>
     public void Switch(
     	Action<string> matchCode, 
-    	Action<string> matchProprietary)
+    	Action<TestNamespace.OtherNamespace.Authorisation1Code> matchProprietary)
     {
         switch (ChoiceType)
         {
@@ -122,7 +122,7 @@ public sealed partial class Authorisation1Choice
                 return;
 
             case ChoiceOf.Proprietary:
-                matchProprietary(Proprietary!);
+                matchProprietary(Proprietary!.Value);
                 return;
 
             default:
@@ -130,6 +130,32 @@ public sealed partial class Authorisation1Choice
         }
     }
 
+    /// <summary>
+    /// Implicitly converts an <see cref="string"/> to an <see cref="Authorisation1Choice"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="string"/> to convert.</param>
+    /// <returns>
+    /// <see cref="Authorisation1Choice"/> instance representing the code.
+    /// </returns>
+    public static implicit operator Authorisation1Choice(string value) => CreateAsCode(value);
+
+    /// <summary>
+    /// Implicitly converts an <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/> to an <see cref="Authorisation1Choice"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="TestNamespace.OtherNamespace.Authorisation1Code"/> to convert.</param>
+    /// <returns>
+    /// <see cref="Authorisation1Choice"/> instance representing the code.
+    /// </returns>
+    public static implicit operator Authorisation1Choice(TestNamespace.OtherNamespace.Authorisation1Code value) => CreateAsProprietary(value);
+
+    /// <summary>
+    /// Determines whether the <see cref="Proprietary"/> property should be serialized.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if <see cref="Proprietary"/> has a value; otherwise, <c>false</c>.
+    /// </returns>
+    [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+    public bool ShouldSerializeProprietary() => Proprietary.HasValue;
 
     /// <summary>
     /// <para>Choice enumeration</para>

--- a/tests/AltaSoft.ChoiceGenerator.Tests/Authorisation1Choice.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/Authorisation1Choice.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using AltaSoft.Choice;
+using AltaSoft.ChoiceGenerator.Tests.OtherNamespace;
 
 namespace AltaSoft.ChoiceGenerator.Tests;
 
@@ -18,18 +19,4 @@ public sealed partial record Authorisation1Choice
     /// </summary>
     [XmlTag("Prtry")]
     public partial Proprietary? Proprietary { get; set; }
-
-
-}
-
-public class Proprietary
-{
-    public string Other { get; set; } = null!;
-
-}
-
-public enum Authorisation1Code
-{
-    One,
-    Two
 }

--- a/tests/AltaSoft.ChoiceGenerator.Tests/ChoiceGeneratorTests.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/ChoiceGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using System.Xml;
 using System.Xml.Serialization;
 using AltaSoft.Choice;
+using AltaSoft.ChoiceGenerator.Tests.OtherNamespace;
 using Xunit;
 
 namespace AltaSoft.ChoiceGenerator.Tests;

--- a/tests/AltaSoft.ChoiceGenerator.Tests/OtherNamespace/Authorisation1Code.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/OtherNamespace/Authorisation1Code.cs
@@ -1,0 +1,7 @@
+﻿namespace AltaSoft.ChoiceGenerator.Tests.OtherNamespace;
+
+public enum Authorisation1Code
+{
+    One,
+    Two
+}

--- a/tests/AltaSoft.ChoiceGenerator.Tests/OtherNamespace/Proprietary.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/OtherNamespace/Proprietary.cs
@@ -1,0 +1,6 @@
+﻿namespace AltaSoft.ChoiceGenerator.Tests.OtherNamespace;
+
+public class Proprietary
+{
+    public string Other { get; set; } = null!;
+}

--- a/tests/AltaSoft.ChoiceGenerator.Tests/TwoValueTypeChoice.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/TwoValueTypeChoice.cs
@@ -1,4 +1,5 @@
 ﻿using AltaSoft.Choice;
+using AltaSoft.ChoiceGenerator.Tests.OtherNamespace;
 
 namespace AltaSoft.ChoiceGenerator.Tests
 {


### PR DESCRIPTION
- Removed `GetFriendlyName` method from `CompilationExt.cs`.
- Added `GetClassFullName` method in `RoslynExt.cs`.
- Changed type name retrieval from `GetFriendlyName()` to `GetFullName()` in `Executor.cs`.