### PR TITLE
Update GitHub Actions workflows for .NET builds

### DIFF
--- a/.github/workflows/build_nuget_dont_publish.yml
+++ b/.github/workflows/build_nuget_dont_publish.yml
@@ -8,27 +8,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with: 
-        dotnet-version: |
-          10.0.x
-          9.0.x
-          8.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
 
-    - name: Extract version from tag
-      run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+      - name: Set version
+        shell: bash
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ] || [ "$VERSION" = "main" ]; then
+            VERSION="0.0.0-local"
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore -c Release
+      - name: Build
+        run: dotnet build --no-restore -c Release
 
 #    - name: Test
 #      run: dotnet test --no-build
 
-    - name: Pack
-      run: dotnet pack --no-build -c Release -o nupkg -p:Version=${{ env.VERSION }}
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o nupkg -p:Version=${{ env.VERSION }}

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -9,27 +9,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with: 
-        dotnet-version: |
-          10.0.x
-          9.0.x
-          8.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
 
-    - name: Extract version from tag
-      run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+      - name: Extract version from tag
+        shell: bash
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - name: Build
-      run: dotnet build --no-restore -c Release
+      - name: Build
+        run: dotnet build --no-restore -c Release
 
-    - name: Pack
-      run: dotnet pack --no-build -c Release -o nupkg -p:Version=${{ env.VERSION }}
+      - name: Pack
+        run: dotnet pack --no-build -c Release -o nupkg -p:Version=${{ env.VERSION }}
 
-    - name: Publish
-      run: dotnet nuget push "nupkg/*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+      - name: Publish
+        run: dotnet nuget push "nupkg/*.nupkg" --skip-duplicate -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Upgraded `actions/checkout` to v4 and `actions/setup-dotnet` to v4 in both `build_nuget_dont_publish.yml` and `publish_nuget.yml`. Improved version extraction with a Bash script and added a fallback version for non-tagged builds. Added `--skip-duplicate` to `dotnet nuget push` in `publish_nuget.yml` to handle duplicate packages. Enhanced YAML readability and consistency.