### PR TITLE
Enhance single-property handling in Executor class

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 	<Product>Choice generator</Product>
 	<Company>ALTA Software llc.</Company>
 	<Copyright>Copyright © 2024 ALTA Software llc.</Copyright>
-	<Version>2.0.0</Version>
+	<Version>2.1.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AltaSoft.Choice.Generator/Executor.cs
+++ b/src/AltaSoft.Choice.Generator/Executor.cs
@@ -100,7 +100,12 @@ internal static class Executor
         {
             var fieldName = p.Name.ToFieldName();
 
-            sb.Append("private ").Append(p.TypeName).Append("? ").Append(fieldName).AppendLine(";").NewLine();
+            sb.Append("private ").Append(p.TypeName);
+            if (isOnly1Property)
+                sb.Append(" ");
+            else
+                sb.Append("? ");
+            sb.Append(fieldName).AppendLine(";").NewLine();
 
             if (p.Summary is not null)
                 sb.AppendSummary(p.Summary);
@@ -127,11 +132,15 @@ internal static class Executor
 
             sb.AppendIfNotEmpty(p.SetterAccessibility.GetPropertyAccessibilityString()).AppendLine("set")
             .OpenBracket()
-            .Append(fieldName).AppendLine(" = value ?? throw new InvalidOperationException(\"Choice value cannot be null\");")
-            .AppendLines(processedProperties.Where(x => x.Name != p.Name).Select(v => $"{v.Name.ToFieldName()} = null;"))
-            .Append("ChoiceType = ChoiceOf.").Append(p.Name).AppendLine(";")
-            .CloseBracket()
-            .CloseBracket();
+            .Append(fieldName);
+            if (isOnly1Property)
+                sb.AppendLine(" = value;");
+            else
+                sb.AppendLine(" = value ?? throw new InvalidOperationException(\"Choice value cannot be null\");");
+            sb.AppendLines(processedProperties.Where(x => x.Name != p.Name).Select(v => $"{v.Name.ToFieldName()} = null;"))
+                .Append("ChoiceType = ChoiceOf.").Append(p.Name).AppendLine(";")
+                .CloseBracket()
+                .CloseBracket();
 
             sb.NewLine();
 
@@ -179,9 +188,12 @@ internal static class Executor
                 .AppendBlock("returns", $"<c>true</c> if <see cref=\"{p}\"/> has a value; otherwise, <c>false</c>.");
 
             sb.AppendLine("[Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]");
-            sb.Append("public bool ShouldSerialize").Append(p).Append("() => ").Append(p)
-                .AppendLine(".HasValue;")
-                .NewLine();
+            sb.Append("public bool ShouldSerialize").Append(p).Append("() => ");
+            if (isOnly1Property)
+                sb.AppendLine("true;");
+            else
+                sb.Append(p).AppendLine(".HasValue;");
+            sb.NewLine();
         }
 
         sb.AppendSummary("<para>Choice enumeration</para>");
@@ -252,7 +264,6 @@ internal static class Executor
 
     private static void ProcessMatch(SourceCodeBuilder sb, List<PropertyDetails> processedProperties)
     {
-
         sb.AppendSummary("<para>Applies the appropriate function based on the current choice type</para>");
         sb.AppendTypeParamDescription("TResult", "The return type of the provided match functions");
         processedProperties.ForEach(x =>
@@ -276,10 +287,13 @@ internal static class Executor
 
         sb.AppendLine("return ChoiceType switch")
             .OpenBracket();
+
+        var isOnlyProperty = processedProperties.Count == 1;
+
         foreach (var prop in processedProperties)
         {
             sb.Append($"ChoiceOf.{prop.Name} => match").Append($"{prop.Name}({prop.Name}!")
-                .AppendIf(prop.TypeSymbol.IsValueType, ".Value")
+                .AppendIf(!isOnlyProperty && prop.TypeSymbol.IsValueType, ".Value")
                 .AppendLine("),");
         }
 
@@ -291,7 +305,6 @@ internal static class Executor
 
     private static void ProcessSwitch(SourceCodeBuilder sb, List<PropertyDetails> processedProperties)
     {
-
         sb.AppendSummary("<para>Applies the appropriate Action based on the current choice type</para>");
         processedProperties.ForEach(x =>
         {
@@ -314,11 +327,14 @@ internal static class Executor
 
         sb.AppendLine("switch (ChoiceType)")
             .OpenBracket();
+
+        var isOnlyProperty = processedProperties.Count == 1;
+
         foreach (var prop in processedProperties)
         {
             sb.AppendSwitchCase($"ChoiceOf.{prop.Name}")
                 .Append($"match{prop.Name}({prop.Name}!")
-                .AppendIf(prop.TypeSymbol.IsValueType, ".Value")
+                .AppendIf(!isOnlyProperty && prop.TypeSymbol.IsValueType, ".Value")
                 .AppendLine(");")
                 .AppendLine("return;")
                 .CloseSwitchCase()
@@ -345,3 +361,4 @@ internal static class Executor
         "System.Xml.Schema"
     ];
 }
+

--- a/tests/AltaSoft.ChoiceGenerator.Tests/ChoiceGeneratorTests.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/ChoiceGeneratorTests.cs
@@ -303,9 +303,9 @@ public class ChoiceGeneratorTests
     [Fact]
     public void GenerateSinglePropertyChoice()
     {
-        var choice = SinglePropertyChoice.CreateAsValue("value");
+        var choice = SinglePropertyStringChoice.CreateAsValue("value");
 
-        Assert.Equal(SinglePropertyChoice.ChoiceOf.Value, choice.ChoiceType);
+        Assert.Equal(SinglePropertyStringChoice.ChoiceOf.Value, choice.ChoiceType);
         Assert.Equal("value", choice.Value);
 
         var matched = choice.Match(_ => "ok");

--- a/tests/AltaSoft.ChoiceGenerator.Tests/SinglePropertyDateOnlyChoice.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/SinglePropertyDateOnlyChoice.cs
@@ -3,7 +3,7 @@ using AltaSoft.Choice;
 namespace AltaSoft.ChoiceGenerator.Tests;
 
 [Choice]
-public sealed partial class SinglePropertyStringChoice
+public sealed partial class SinglePropertyDateOnlyChoice
 {
     public required partial string Value { get; set; }
 }

--- a/tests/AltaSoft.ChoiceGenerator.Tests/SinglePropertyIntChoice.cs
+++ b/tests/AltaSoft.ChoiceGenerator.Tests/SinglePropertyIntChoice.cs
@@ -1,0 +1,9 @@
+using AltaSoft.Choice;
+
+namespace AltaSoft.ChoiceGenerator.Tests;
+
+[Choice]
+public sealed partial class SinglePropertyIntChoice
+{
+    public required partial int Value { get; set; }
+}


### PR DESCRIPTION
Updated `Executor` to optimize handling of single-property cases:
- Adjusted private field generation and property setters.
- Updated `ShouldSerialize` to return `true` for single-property cases.
- Improved `ProcessMatch` and `ProcessSwitch` methods.

Renamed `SinglePropertyChoice` to `SinglePropertyStringChoice` and updated related tests. Added new classes `SinglePropertyDateOnlyChoice` and `SinglePropertyIntChoice` with required `Value` properties.

Incremented `Version` in `Directory.Build.props` to `2.1.4`.